### PR TITLE
Download dependencies

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -79,7 +79,10 @@ LT_INIT
 AC_ARG_ENABLE(builddeps,
               [AS_HELP_STRING([--enable-builddeps],
                               [Build unfound dependencies])],
-              [AS_IF([test "x$enable_builddeps" != xno], [enable_builddeps=yes])],
+              [AS_IF([test "x$enable_builddeps" != xno], 
+                     [enable_builddeps=yes
+                      > contrib/to_build
+                      ])],
               [enable_builddeps=no])
 
 # Check the number of jobs. Depending on the operative system (GNU/Linux or
@@ -804,6 +807,11 @@ AS_IF([test "x$numpy_includedir" = x],
       [has_numpy=0], [has_numpy=1;])
 AC_SUBST(HAVE_PYTHON, [$has_numpy])
 AM_CONDITIONAL([COND_NUMPY], [test "x$numpy_includedir" != x])
+
+
+AC_DEFUN([ADD_TO_BUILD_LIST],[
+  echo $1 >> contrib/to_build
+])
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -76,6 +76,11 @@ LT_INIT
 
 
 
+AC_ARG_ENABLE(builddeps,
+              [AS_HELP_STRING([--enable-builddeps],
+                              [Build unfound dependencies])],
+              [AS_IF([test "x$enable_builddeps" != xno], [enable_builddeps=yes])],
+              [enable_builddeps=no])
 
 # Check the number of jobs. Depending on the operative system (GNU/Linux or
 # macOS), the way of getting the number of cores is different. If the

--- a/configure.ac
+++ b/configure.ac
@@ -814,7 +814,23 @@ AC_DEFUN([ADD_TO_BUILD_LIST],[
 ])
 
 
+AS_IF([test "x$missing_mandatory" = "xyes" -a "x$enable_builddeps" = "xyes"],
+      [
+      AS_IF([test "x$has_gsl" = "xno"], [ ADD_TO_BUILD_LIST([gsl])])
+      AS_IF([test "x$has_libgit2" = "x0"], [ ADD_TO_BUILD_LIST([libgit2])])
+      AS_IF([test "x$has_cmath" = "xno"], [ ADD_TO_BUILD_LIST([cmath])])
+      AS_IF([test "x$has_wcslib" = "xno"], [ ADD_TO_BUILD_LIST([wcslib])])
+      AS_IF([test "x$has_cfitsio" = "xno"], [ ADD_TO_BUILD_LIST([cfitsio])])
+      AS_IF([test "x$has_libtiff" = "xno"], [ ADD_TO_BUILD_LIST([libtiff])])
+      AS_IF([test "x$has_libjpeg" = "xno"], [ ADD_TO_BUILD_LIST([libjpeg])])
+      AS_IF([test "x$has_gslcblas" = "xno"], [ ADD_TO_BUILD_LIST([gslcblas])])
 
+      AS_IF([test "x$has_curl" = "xno"], [ ADD_TO_BUILD_LIST([curl])])
+      AS_IF([test "x$has_ds9" = "xno"], [ ADD_TO_BUILD_LIST([ds9])])
+      AS_IF([test "x$has_topcat" = "xno"], [ ADD_TO_BUILD_LIST([topcat])])
+      [cd contrib && ./bootstrap && make && cd ..]
+      [missing_mandatory = "no"]
+       ])
 
 
 # If any necessary dependency is missing inform the user and abort.

--- a/contrib/bootstrap
+++ b/contrib/bootstrap
@@ -1,0 +1,34 @@
+#!/bin/bash
+BOOTSTRAP_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+cat > Makefile << EOF
+CONTRIB_DIR = $BOOTSTRAP_PATH
+MAKEFLAGS += -j$CPUS
+CMAKEFLAGS += --parallel=$CPUS
+PREFIX=\$(abspath ./build)
+PATH=\${PREFIX}/bin:$PATH
+EOF
+
+mkdir -p $BOOTSTRAP_PATH/tarballs
+
+
+
+file="to_build"
+if [ -e $file ]
+then
+  for dependency in $(cat $file)
+  do
+    echo ".$dependency: .build$dependency" >> Makefile
+    TARGETS="$TARGETS .build$dependency"
+  done
+else
+  echo "$file not found. Run configure with --enable-builddeps"
+fi
+
+
+cat >> Makefile << EOF
+all: $TARGETS
+	@echo "All listed dependencies are built"
+
+include \$(CONTRIB_DIR)/tools.mak
+EOF

--- a/contrib/packages.mak
+++ b/contrib/packages.mak
@@ -1,5 +1,5 @@
 GSL_URL=https://mirror.ibcp.fr/pub/gnu/gsl/gsl-latest.tar.gz
-FITSIO_URL=https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio-4.2.0.tar.gz
+CFITSIO_URL=https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio-4.2.0.tar.gz
 WCSLIB_URL=http://www.atnf.csiro.au/people/mcalabre/WCS/wcslib-7.12.tar.bz2
 LIBJPEG_URL=http://ijg.org/files/jpegsrc.v9e.tar.gz
 LIBTIFF_URL=https://download.osgeo.org/libtiff/tiff-4.4.0.tar.gz

--- a/contrib/packages.mak
+++ b/contrib/packages.mak
@@ -1,0 +1,6 @@
+GSL_URL=https://mirror.ibcp.fr/pub/gnu/gsl/gsl-latest.tar.gz
+FITSIO_URL=https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio-4.2.0.tar.gz
+WCSLIB_URL=http://www.atnf.csiro.au/people/mcalabre/WCS/wcslib-7.12.tar.bz2
+LIBJPEG_URL=http://ijg.org/files/jpegsrc.v9e.tar.gz
+LIBTIFF_URL=https://download.osgeo.org/libtiff/tiff-4.4.0.tar.gz
+LIBGIT2_URL=https://github.com/libgit2/libgit2/archive/refs/tags/v1.6.3.tar.gz

--- a/contrib/tools.mak
+++ b/contrib/tools.mak
@@ -53,7 +53,16 @@ libgit2: libgit2-1.6.3.tar.gz
 	sudo cmake --build . --target install &&\
 	cd $(CONTRIB_DIR) && touch .buildlibgit2
 
-.buildwcslib:
+wcslib-7.12.tar.bz2:
+	$(call download,$(WCSLIB_URL))
+
+wcslib: wcslib-7.12.tar.bz2
+	$(call UNPACK,wcslib-7.12.tar.bz2,wcslib)
+
+.buildwcslib: wcslib
+	cd wcslib && ./configure  && make -j$(nproc) && sudo  make install
+	cd $(CONTRIB_DIR) && touch .buildwcslib
+
 .buildlibtiff:
 .buildlibjpeg:
 .buildgslcblas:

--- a/contrib/tools.mak
+++ b/contrib/tools.mak
@@ -31,10 +31,19 @@ gsl: gsl-latest.tar.gz
 .buildgsl: gsl
 	cd gsl && ./configure  && make -j$(nproc) && sudo  make install
 	cd $(CONTRIB_DIR) && touch .buildgsl
-		
+
+cfitsio-4.2.0.tar.gz:
+	$(call download,$(CFITSIO_URL))
+
+cfitsio: cfitsio-4.2.0.tar.gz
+	$(call UNPACK,cfitsio-4.2.0.tar.gz,cfitsio)
+
+.buildcfitsio: cfitsio
+	cd cfitsio && ./configure --prefix=/usr  && make -j$(nproc) && sudo  make install
+	cd $(CONTRIB_DIR) && touch .buildcfitsio
+
 .buildlibgit2:
 .buildwcslib:
-.buildcfitsio:
 .buildlibtiff:
 .buildlibjpeg:
 .buildgslcblas:

--- a/contrib/tools.mak
+++ b/contrib/tools.mak
@@ -32,3 +32,11 @@ gsl: gsl-latest.tar.gz
 	cd gsl && ./configure  && make -j$(nproc) && sudo  make install
 	cd $(CONTRIB_DIR) && touch .buildgsl
 		
+.buildlibgit2:
+.buildwcslib:
+.buildcfitsio:
+.buildlibtiff:
+.buildlibjpeg:
+.buildgslcblas:
+.buildds9:
+.buildtopcat:

--- a/contrib/tools.mak
+++ b/contrib/tools.mak
@@ -63,7 +63,16 @@ wcslib: wcslib-7.12.tar.bz2
 	cd wcslib && ./configure  && make -j$(nproc) && sudo  make install
 	cd $(CONTRIB_DIR) && touch .buildwcslib
 
-.buildlibtiff:
+libtiff-4.4.0.tar.gz:
+	$(call download,$(LIBTIFF_URL))
+
+libtiff: libtiff-4.4.0.tar.gz
+	$(call UNPACK,libtiff-4.4.0.tar.gz,libtiff)
+
+.buildlibtiff: libtiff
+	cd libtiff && ./configure  && make -j$(nproc) && sudo  make install
+	cd $(CONTRIB_DIR) && touch .buildlibtiff
+
 .buildlibjpeg:
 .buildgslcblas:
 .buildds9:

--- a/contrib/tools.mak
+++ b/contrib/tools.mak
@@ -42,7 +42,17 @@ cfitsio: cfitsio-4.2.0.tar.gz
 	cd cfitsio && ./configure --prefix=/usr  && make -j$(nproc) && sudo  make install
 	cd $(CONTRIB_DIR) && touch .buildcfitsio
 
-.buildlibgit2:
+libgit2-1.6.3.tar.gz:
+	$(call download,$(LIBGIT2_URL))
+
+libgit2: libgit2-1.6.3.tar.gz
+	$(call UNPACK,libgit2-1.6.3.tar.gz,libgit2)
+
+.buildlibgit2: libgit2
+	cd libgit2 && mkdir -p build && cd build && cmake .. &&\
+	sudo cmake --build . --target install &&\
+	cd $(CONTRIB_DIR) && touch .buildlibgit2
+
 .buildwcslib:
 .buildlibtiff:
 .buildlibjpeg:

--- a/contrib/tools.mak
+++ b/contrib/tools.mak
@@ -73,7 +73,16 @@ libtiff: libtiff-4.4.0.tar.gz
 	cd libtiff && ./configure  && make -j$(nproc) && sudo  make install
 	cd $(CONTRIB_DIR) && touch .buildlibtiff
 
-.buildlibjpeg:
+libjpeg-9e.tar.gz:
+	$(call download,$(LIBJPEG_URL))
+
+libjpeg: libjpeg-9e.tar.gz
+	$(call UNPACK,libjpeg-9e.tar.gz,libjpeg)
+
+.buildlibjpeg: libjpeg
+	cd libjpeg && ./configure  && make -j$(nproc) && sudo  make install
+	cd $(CONTRIB_DIR) && touch .buildlibjpeg
+
 .buildgslcblas:
 .buildds9:
 .buildtopcat:

--- a/contrib/tools.mak
+++ b/contrib/tools.mak
@@ -29,4 +29,6 @@ gsl: gsl-latest.tar.gz
 	$(call UNPACK,gsl-latest.tar.gz,gsl)
 
 .buildgsl: gsl
+	cd gsl && ./configure  && make -j$(nproc) && sudo  make install
+	cd $(CONTRIB_DIR) && touch .buildgsl
 		

--- a/contrib/tools.mak
+++ b/contrib/tools.mak
@@ -1,0 +1,2 @@
+include $(CONTRIB_DIR)/packages.mak
+TARBALLS_DIR := $(CONTRIB_DIR)/tarballs

--- a/contrib/tools.mak
+++ b/contrib/tools.mak
@@ -1,2 +1,32 @@
 include $(CONTRIB_DIR)/packages.mak
 TARBALLS_DIR := $(CONTRIB_DIR)/tarballs
+UNPACK_DIR := $(CONTRIB_DIR)/unpacked 
+
+
+ifeq ($(shell curl --version >/dev/null 2>&1 || echo FAIL),)
+download = curl -f -L -- "$(1)" > "$@.tmp" && touch $@.tmp &&\
+	   mv $@.tmp $@
+else ifeq ($(shell wget --version >/dev/null 2>&1 || echo FAIL),)
+download = rm -f $@.tmp && \
+	wget --passive -c -p -O $@.tmp "$(1)" && \
+	touch $@.tmp && \
+	mv $@.tmp $@
+else ifeq ($(which fetch >/dev/null 2>&1 || echo FAIL),)
+download = rm -f $@.tmp && \
+	fetch -p -o $@.tmp "$(1)" && \
+	touch $@.tmp && \
+	mv $@.tmp $@
+else
+download = $(error Neither curl nor wget found!)
+endif
+
+UNPACK=mkdir -p $2 && tar xvf $1 --strip-components=1 --directory=$2
+
+gsl-latest.tar.gz:
+	$(call download,$(GSL_URL))
+
+gsl: gsl-latest.tar.gz
+	$(call UNPACK,gsl-latest.tar.gz,gsl)
+
+.buildgsl: gsl
+		


### PR DESCRIPTION
This lets user configue with --enable-builddeps flag.

If enabled, mandatory missing dependencies will be built when the configuration script is being run.